### PR TITLE
bat upload jdf u -list

### DIFF
--- a/lib/ftpUpload.js
+++ b/lib/ftpUpload.js
@@ -124,6 +124,12 @@ exports.init = function(argv, hasConfig, haslog, callback){
 		jdf.argvInit('output', argv, function(){
 			ftpFn(uploadSource, jdf.config.previewServerDir);
 		});
+	}else if(argv[3] == '-list' && jdf.config.uploadList){
+		// 根据config.json配置上传
+		argv[3] = jdf.config.uploadList;
+		jdf.argvInit('output', argv, function(){
+			ftpFn(uploadSource, uploadTarget);
+		});
 	}else {
 		//default upload
 		outputFnOnce();

--- a/lib/jdf.js
+++ b/lib/jdf.js
@@ -69,6 +69,7 @@ jdf.help = function() {
         '      -nc        upload css/js dir to preview server dir use newcdn url',
         '      -nh        upload html dir to preview server dir use newcdn url',
         '      -custom    upload a dir/file to server',
+        '      -list      upload file list from config.json to server',
         '',
         '    widget',
         '      -all       preview all widget',


### PR DESCRIPTION
可在 config.json
配置中增加uploadList节点，value可以为一个或多个文件，达到多文件批量上传效果，可将短期内需要反复上传的文件配置在其中，如
"uploadList":"css/i/selected-icon.png,js/" 批量上传无需反复输入多个文件名
![_112515_014510_pm](https://cloud.githubusercontent.com/assets/1539081/11403160/6a66a880-93d6-11e5-94fd-d4586a932bd1.jpg)
![_112515_014858_pm](https://cloud.githubusercontent.com/assets/1539081/11403165/6fa8ff50-93d6-11e5-99a8-087b20ef8216.jpg)
![_112515_020422_pm](https://cloud.githubusercontent.com/assets/1539081/11403168/736bb9c0-93d6-11e5-85b9-9ed5bcb91804.jpg)
