### PR TITLE
fix imagesSuffix：true; png path bug

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -100,6 +100,25 @@ compress.init = function(rSource, isdebug, config, getProject){
 			if ($.is.css(source) && jdf.config.output.compressCss) {
 				var sourceCode = compress.css(source, isdebug);
 				f.write(source, sourceCode);
+			} else if($.is.css(source)){
+				/*fix
+				情况：config.json文件中api为
+				"output":{
+				    "cssImagesUrlReplace": false,
+				    "cssCombo": false,
+				    "combineWidgetCss":true,
+				    "compressPng":true,
+				    "compressCss":false,    //主要原因
+				    "cssSprite":true,
+				    "imagesSuffix":2
+				}
+				合成后的图片名称带有时间戳 例：widget20160105172007.png
+				但是widget.css的文件中图片名称未加时间戳  例：例：widget.png
+				so 我瞎写了一个。。
+				*/
+				//我写的不好，威哥，春哥，啥时候帮忙改改呀，好修复这里
+				var sourceCode = compress.css2(source, isdebug);
+				f.write(source, sourceCode);
 			}
 			
 			//png optimize
@@ -488,6 +507,18 @@ compress.css = function(source, isdebug){
 	
 	return result;
 };
+
+compress.css2 = function(source, isdebug){//我写的不好，威哥，春哥，啥时候帮忙改改呀，好修复这里
+	var isdebug = isdebug || false;
+
+	if (!f.exists(source)) {return;}
+	var sourceCode = f.read(source);
+	var result = sourceCode;
+	if(jdf.config.output.imagesSuffix){//替换imagesSuffix情况下的image名称
+		result = compress.imagesSuffix(source, result);
+	}
+	return result;
+}
 
 /**
 * css中图片路径替换


### PR DESCRIPTION
情况：config.json文件中api为
"output":{
    "cssImagesUrlReplace": false,
    "cssCombo": false,
    "combineWidgetCss":true,
    "compressPng":true,
    "compressCss":false,    //主要原因
    "cssSprite":true,
    "imagesSuffix":2
}
合成后的图片名称带有时间戳 例：widget20160105172007.png
但是widget.css的文件中图片名称未加时间戳  例：例：widget.png
so 我瞎写了一个。。
*/
//我写的不好，威哥，春哥，啥时候帮忙改改呀，好修复这里