### PR TITLE
添加了自定义-path 参数

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 npm-debug.log
 .svn
+.idea
 .DS_Store
 test/dest

--- a/lib/jdf.js
+++ b/lib/jdf.js
@@ -60,6 +60,7 @@ jdf.help = function() {
         '      dirname    output your own custom dirname',
         '      -debug     uncompressed js,css,images for test',
         '      -backup    backup outputdir to tags dir',
+        '      -path [p]  replace projectPath to specified path option',
         '',
         '    upload       upload css/js dir to remote sever',
         //'    -html      upload output project (include html) ',
@@ -304,6 +305,7 @@ jdf.argvInit = function(runType, argv, callback) {
         	jdf.buildMain(runType);
             //默认
             var outputType = 'default',
+                projectPath = null,
                 outputList, isbackup = false,
                 isdebug = false;
 
@@ -314,6 +316,12 @@ jdf.argvInit = function(runType, argv, callback) {
                 //custom自定义
                 outputType = 'custom';
                 outputList = cmd3;
+
+                //projectPath自定义
+                if (cmd3 == '-path') {
+                    projectPath = cmd4;
+                    outputType = 'default';
+                }
 
                 //debug(不压缩)
                 if (cmd3 == '-debug' || cmd4 == '-debug') {
@@ -350,6 +358,7 @@ jdf.argvInit = function(runType, argv, callback) {
                 Output.init({
                     type: outputType,
                     list: outputList,
+                    projectPath: projectPath,
                     isbackup: isbackup,
                     isdebug: isdebug,
                     callback: callback

--- a/lib/output.js
+++ b/lib/output.js
@@ -40,7 +40,7 @@ output.init = function(options){
 	var encoding = jdf.config.output.encoding;
 	var excludeFiles = jdf.config.output.excludeFiles;
 	var weinre = jdf.config.build.weinre;
-	var outputdir = outputdirName+'/'+jdf.getProjectPath();
+	var outputdir = outputdirName+'/'+ (options.projectPath || jdf.getProjectPath());
 	var isbackup = typeof(isbackup) == 'undefined' ? false : isbackup;
 	
 	//[notice]输出路径暂不可配置


### PR DESCRIPTION
1> cli 支持控制自己定义 projectPath 参数，方便在不改配置文件的情况下部署不同的分支版本到测试环境
```bash
$ jdf u -path item/1.0.0
```
2> 添加 .idea 到 .gitignore 文件

我的情况是这样的，开发状态不同的功能分支部署在不同的版本目录下面，比如：
```
branch: feature/A
projectPath: item/1.0.0-A

branch: feature/B
projectPath: item/1.0.0-B
```
如果直接改对应分支 config.json 里面的 projectPath 会在合并分支的时候 merge 到 master

